### PR TITLE
Master password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout-sw600dp/dialog_generate_password.xml
+++ b/app/src/main/res/layout-sw600dp/dialog_generate_password.xml
@@ -84,7 +84,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textPassword"
-            android:layout_toStartOf="@+id/visibilityButton" />
+            android:layout_toStartOf="@+id/visibilityButton"
+            android:importantForAccessibility="no" />
 
         <ImageButton
             android:id="@+id/visibilityButton"

--- a/app/src/main/res/layout-sw720dp/dialog_generate_password.xml
+++ b/app/src/main/res/layout-sw720dp/dialog_generate_password.xml
@@ -84,7 +84,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textPassword"
-            android:layout_toStartOf="@+id/visibilityButton" />
+            android:layout_toStartOf="@+id/visibilityButton"
+            android:importantForAccessibility="no" />
 
         <ImageButton
             android:id="@+id/visibilityButton"

--- a/app/src/main/res/layout/dialog_generate_password.xml
+++ b/app/src/main/res/layout/dialog_generate_password.xml
@@ -88,7 +88,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textPassword"
-                android:layout_toStartOf="@+id/visibilityButton" />
+                android:layout_toStartOf="@+id/visibilityButton"
+                android:importantForAccessibility="no" />
 
             <ImageButton
                 android:id="@+id/visibilityButton"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, master password, should be ignored for the accessibility service, so such attacks can not be happened.
