### PR TITLE
Fix wrong item selected when list is filtered

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
@@ -124,7 +124,7 @@ public class MainActivity extends BaseActivity {
                         Bundle bundle = new Bundle();
 
                         //Gets ID for look up in DB
-                        MetaData temp = metadatalist.get(position);
+                        MetaData temp = adapter.getItem(position);
 
                         bundle.putInt("position", temp.getID());
                         bundle.putString("hash_algorithm", hash_algorithm);

--- a/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/helpers/MetaDataAdapter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/helpers/MetaDataAdapter.java
@@ -131,6 +131,10 @@ public class MetaDataAdapter extends RecyclerView.Adapter<MetaDataAdapter.MetaDa
         this.metaDataList = metaDataList;
     }
 
+    public MetaData getItem(int position) {
+        return metaDataList.get(position);
+    }
+
     public MetaData removeItem(int position) {
         final MetaData metaData = metaDataList.remove(position);
         notifyItemRemoved(position);


### PR DESCRIPTION
The onClickListener does not take into account that the ids for entries in the password list change once a filter/search is applied. If searching for a specific password entry the list is filtered correctly, but when clicking on the entry the password generation dialog will be filled with the data of a different password list entry.

E.g. if you search for "domain" within the App's example data, it will show the correct entry in the list. But if you click on that entry, it will generate the password for the "email" entry (because that is the first entry in the unfiltered list).