### PR TITLE
left swipe deletes wrong item when filter is active fixed

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
@@ -217,14 +217,16 @@ public class MainActivity extends BaseActivity {
 
     public void deleteItem(int position) {
 
-        MetaData toDeleteMetaData = metadatalist.get(position);
+        MetaData toDeleteMetaData = adapter.getItem(position);
         final MetaData toDeleteMetaDataFinal = toDeleteMetaData;
 
         //Removes MetaData from DB
         database.deleteMetaData(toDeleteMetaData);
 
         //Removes MetaData from List in View
-        metadatalist.remove(position);
+        adapter.removeItem(position);
+        metadatalist.remove(toDeleteMetaData);
+
 
         final int finalPosition = position;
 


### PR DESCRIPTION
When filter is active and you swipe left to delete an item, the wrong item gets deleted.