### PR TITLE
Honor default preferences instead of using hardcoded defaults

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/MainActivity.java
@@ -17,6 +17,7 @@
 
 package org.secuso.privacyfriendlypasswordgenerator.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -313,13 +314,15 @@ public class MainActivity extends BaseActivity {
     }
 
     public void loadPreferences() {
-
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
+	Context context = getBaseContext();
+	SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 
         clipboard_enabled = sharedPreferences.getBoolean("clipboard_enabled", false);
         bindToDevice_enabled = sharedPreferences.getBoolean("bindToDevice_enabled", false);
-        hash_algorithm = sharedPreferences.getString("hash_algorithm", "SHA256");
-        String tempIterations = sharedPreferences.getString("hash_iterations", "1000");
+	String default_hash_algorithm = context.getResources().getString(R.string.default_hash_algorithm);
+	hash_algorithm = sharedPreferences.getString("hash_algorithm", default_hash_algorithm);
+	String default_iterations = context.getResources().getString(R.string.default_iterations);
+	String tempIterations = sharedPreferences.getString("hash_iterations", default_iterations);
         number_iterations = Integer.parseInt(tempIterations);
     }
 


### PR DESCRIPTION
Contrary to the default preference value of 2000 iterations a hardcoded value of 1000 is used. Only after opening the settings dialog the 2000 iterations will become effective. I fixed it here. The 1000 default value is hardcoded into
app/src/main/java/org/secuso/privacyfriendlypasswordgenerator/activities/SettingsActivity.java
as well, even though it does not seem to have an effect here.
Both my Java and Android knowledge are very limited so far, so this is rather a suggestion that I basically copied from Stackexchange, so someone should look into this,

I strongly vote for turning the hash algorithm / number of iterations into per-account settings, too. I do unterstand that from a technical point those are rather per-device settings, but making them per-account settings would
a) serve as a reminder that those values actually effect the generated password (I know its in the docs, I'm leaning more towards practicality here)
b) Would allow to open the 'old password / new password' dialog as right now, changing the hash value 'corrupts' the entire db
but goes otherwise unnoticed
c) Users can choose to wait longer for the generated password if the use-case for that password is worth the sacrifice